### PR TITLE
Fix for repeating decimals on divide operations

### DIFF
--- a/src/com/sb/elsinore/OutputControl.java
+++ b/src/com/sb/elsinore/OutputControl.java
@@ -1,4 +1,5 @@
 package com.sb.elsinore;
+import com.sb.util.MathUtil;
 import java.math.BigDecimal;
 
 import jGPIO.InvalidGPIOException;
@@ -124,7 +125,7 @@ public final class OutputControl implements Runnable {
                         BigDecimal lTime = new BigDecimal(System.currentTimeMillis())
                             .subtract(coolStopTime);
 
-                        if ((lTime.divide(THOUSAND)).compareTo(this.coolDelay) > 0) {
+                        if (MathUtil.divide(lTime,THOUSAND).compareTo(this.coolDelay) > 0) {
                             // not slept enough
                             break;
                         }
@@ -136,7 +137,7 @@ public final class OutputControl implements Runnable {
                         coolStopTime = BigDecimal.valueOf(System.currentTimeMillis());
                     } else if (fDuty.compareTo(BigDecimal.ZERO) > 0) {
                         // calc the on off time
-                        duty = fDuty.divide(HUNDRED);
+                        duty = MathUtil.divide(fDuty,HUNDRED);
                         onTime = duty.multiply(fTimeh);
                         offTime = fTimeh.multiply(BigDecimal.ONE.subtract(duty));
                         BrewServer.LOG.info("On: " + onTime
@@ -148,7 +149,7 @@ public final class OutputControl implements Runnable {
                         Thread.sleep(offTime.intValue());
                     } else if (fDuty.compareTo(BigDecimal.ZERO) < 0) {
                         // calc the on off time
-                        duty = fDuty.abs().divide(HUNDRED);
+                        duty = MathUtil.divide(fDuty.abs(),HUNDRED);
                         onTime = duty.multiply(fTimec);
                         offTime = fTimeh.multiply(BigDecimal.ONE.subtract(duty));
 

--- a/src/com/sb/elsinore/PID.java
+++ b/src/com/sb/elsinore/PID.java
@@ -1,4 +1,5 @@
 package com.sb.elsinore;
+import com.sb.util.MathUtil;
 import jGPIO.InvalidGPIOException;
 import jGPIO.OutPin;
 
@@ -453,11 +454,17 @@ public final class PID implements Runnable {
     private BigDecimal calcAverage() {
         int size = tempList.size();
 
+        if ( size == 0 )
+        {
+            return new BigDecimal(-999.0);
+        }
+        
         BigDecimal total = new BigDecimal(0.0);
         for (BigDecimal t : tempList) {
             total = total.add(t);
         }
-        return total.divide(BigDecimal.valueOf(size));
+        
+        return MathUtil.divide(total,size);
     }
 
     /**
@@ -544,7 +551,7 @@ public final class PID implements Runnable {
         if (previousTime.compareTo(BigDecimal.ZERO) == 0) {
             previousTime = currentTime;
         }
-        BigDecimal dt = currentTime.subtract(previousTime).divide(THOUSAND);
+        BigDecimal dt = MathUtil.divide(currentTime.subtract(previousTime),THOUSAND);
         if (dt.compareTo(BigDecimal.ZERO) == 0) {
             return outputControl.getDuty();
         }

--- a/src/com/sb/elsinore/Temp.java
+++ b/src/com/sb/elsinore/Temp.java
@@ -1,4 +1,5 @@
 package com.sb.elsinore;
+import com.sb.util.MathUtil;
 import jGPIO.GPIO.Direction;
 import jGPIO.InPin;
 import jGPIO.InvalidGPIOException;
@@ -376,7 +377,7 @@ public final class Temp implements Runnable {
      */
     public static BigDecimal fToC(final BigDecimal currentTemp) {
         BigDecimal t = currentTemp.subtract(FREEZING);
-        t = t.multiply(new BigDecimal(5)).divide(new BigDecimal(9));
+        t = MathUtil.divide(MathUtil.multiply(t, 5),9);
         return t;
     }
 
@@ -385,7 +386,7 @@ public final class Temp implements Runnable {
      * @return Temperature in Fahrenheit
      */
     public static BigDecimal cToF(final BigDecimal currentTemp) {
-        BigDecimal t = currentTemp.multiply(new BigDecimal(9)).divide(new BigDecimal(5));
+        BigDecimal t = MathUtil.divide(MathUtil.multiply(currentTemp, 9),5);
         t = t.add(FREEZING);
         return t;
     }
@@ -482,14 +483,12 @@ public final class Temp implements Runnable {
                 int t = line.indexOf("t=");
                 temp = line.substring(t + 2);
                 BigDecimal tTemp = new BigDecimal(temp);
-                this.currentTemp = tTemp.divide(BigDecimal.TEN
-                        .multiply(BigDecimal.TEN.multiply(BigDecimal.TEN)));
+                this.currentTemp = MathUtil.divide(tTemp, 1000);
                 this.currentError = null;
             } else {
                 // System Temperature
                 BigDecimal tTemp = new BigDecimal(line);
-                this.currentTemp = tTemp.divide(BigDecimal.TEN
-                        .multiply(BigDecimal.TEN.multiply(BigDecimal.TEN)));
+                this.currentTemp = MathUtil.divide(tTemp, 1000);
             }
 
         } catch (IOException ie) {
@@ -629,7 +628,7 @@ public final class Temp implements Runnable {
                 BigDecimal keyDiff = pairs.getKey().subtract(prevPair.getKey());
                 BigDecimal valueDiff =
                         pairs.getValue().subtract(prevPair.getValue());
-                BigDecimal newMultiplier = valueDiff.divide(keyDiff);
+                BigDecimal newMultiplier = MathUtil.divide(valueDiff, keyDiff);
                 BigDecimal newConstant =
                         pairs.getValue().subtract(valueDiff.multiply(keyDiff));
 
@@ -736,8 +735,7 @@ public final class Temp implements Runnable {
                         // assume it's linear
                         BigDecimal volRange = curKey.subtract(prevKey);
                         BigDecimal readingRange = curValue.subtract(prevValue);
-                        BigDecimal ratio = pinValue.subtract(prevValue)
-                                .divide(readingRange);
+                        BigDecimal ratio = MathUtil.divide(pinValue.subtract(prevValue),readingRange);
                         BigDecimal volDiff = ratio.multiply(volRange);
                         tVolume = volDiff.add(prevKey);
                     }
@@ -748,8 +746,7 @@ public final class Temp implements Runnable {
                     // Try to extrapolate
                     BigDecimal volRange = curKey.subtract(prevKey);
                     BigDecimal readingRange = curValue.subtract(prevValue);
-                    BigDecimal ratio = pinValue.subtract(prevValue)
-                            .divide(readingRange);
+                    BigDecimal ratio = MathUtil.divide(pinValue.subtract(prevValue),readingRange);
                     BigDecimal volDiff = ratio.multiply(volRange);
                     tVolume = volDiff.add(prevKey);
                 }
@@ -835,8 +832,8 @@ public final class Temp implements Runnable {
         }
 
         // read in ten values
-        BigDecimal avgValue = total.divide(maxReads);
-
+        BigDecimal avgValue = MathUtil.divide(total, maxReads);
+        
         System.out.println("Read " + avgValue + " for "
                 + volume + " " + volumeUnit.toString());
 

--- a/src/com/sb/util/MathUtil.java
+++ b/src/com/sb/util/MathUtil.java
@@ -1,0 +1,38 @@
+package com.sb.util;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+
+/**
+ *
+ */
+public final class MathUtil
+{
+    
+    private static MathContext context = MathContext.DECIMAL32;
+    
+    public static BigDecimal divide(BigDecimal numerator, BigDecimal denominator)
+    {
+        return numerator.divide(denominator, context);
+    }
+    
+    public static BigDecimal divide(BigDecimal numerator, int denominator)
+    {
+        return divide(numerator, BigDecimal.valueOf(denominator));
+    }
+    
+    public static BigDecimal divide(int numerator, int denominator)
+    {
+        return divide(BigDecimal.valueOf(numerator), denominator);
+    }
+    
+    public static BigDecimal multiply(BigDecimal a, int multiplier)
+    {
+        return a.multiply(BigDecimal.valueOf(multiplier));
+    }
+    
+    
+    
+    
+    
+}


### PR DESCRIPTION
Occasionally would see an uncaught error when calling
BigDecimal.divide(..) because there was no math context set which would
tell it what to do with repeating decimals.  I created a utility to
perform the Divides and set the math context there.

For now I put a default context of 32 bit precision.  That can be changed in the MathUtil class for higher precision if needed.
